### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features
    * 1 Emergency switch input, directly wired to hardware-reset stepper drivers.
    * 2 high power PWM (Motor voltage, ~20A)
    * 2 Open Collector PWM for smaller loads (Up to 20V, ~2A)
-   * 2 Open Collector Auxilliary Outputs (Up to 20V, ~2A)
+   * 2 Open Collector Auxiliary Outputs (Up to 20V, ~2A)
    * 3 endswitch inputs.
    * 3 temperature sensor inputs.
 


### PR DESCRIPTION
hzeller, I've corrected a typographical error in the documentation of the [bumps](https://github.com/hzeller/bumps) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
